### PR TITLE
Fix accidental fall-throughs in switch statement

### DIFF
--- a/SDHT.h
+++ b/SDHT.h
@@ -42,12 +42,14 @@ class SDHT {
         case DHT12:
           _humidity = (data[0] * 10) + data[1];
           _celsius = ((data[2] * 10) + (data[3] & 0x7F)) * ((data[3] & 0x80) ? -1 : 1);
-          
+          break;
+
         case DHT21:
         case DHT22:
           _humidity = (uint16_t(data[0] << 8) | data[1]);
           _celsius = (uint16_t((data[2] & 0x7F) << 8) | data[3]) * ((data[2] & 0x80) ? -1 : 1);
-          
+          break;
+
         default: return false;
       }
       return true;


### PR DESCRIPTION
This would result in incorrect readings for DHT12 and failure reports
for all types but DHT11.

Reverts 31491330c2